### PR TITLE
Fix a typo in export.js

### DIFF
--- a/exporter/export.js
+++ b/exporter/export.js
@@ -33,7 +33,7 @@ var telemetry_measures_found = telemetry_versions_filtered.then(function() {
       Telemetry.getFilterOptions(parts[0], parts[1], function(filters) {
         var measureMap = {};
         filters.metric.forEach(function(measure) {
-          if (histogram_definitions[measure] && histograms_definitions[measure].keyed != true) {
+          if (histogram_definitions[measure] && histogram_definitions[measure].keyed != true) {
             measureMap[measure] = true;
           }
         })


### PR DESCRIPTION
Due to the typo, this was failing locally for me, not even fetching the files. I'm not quite sure why this isn't failing on the server.
